### PR TITLE
Update label maker for wiki.skullspace.ca move

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a script to generate tool labels. For the most basic label
 ./label_maker.sh 3d_printer
 ```
 
-This will generate a default label linking to skullspace.ca/wiki/index.php/3d_printer, setting SkullSpace as the owner, requiring training, and disallowing hacking.
+This will generate a default label linking to wiki.skullspace.ca/index.php/3d_printer, setting SkullSpace as the owner, requiring training, and disallowing hacking.
 
 If the tool is not owned by SkullSpace, you can specify the owner with the -o flag.
 

--- a/label_maker.sh
+++ b/label_maker.sh
@@ -20,7 +20,7 @@ done
 shift $(( OPTIND-1 ))
 
 TOOL_NAME=$1
-URL="skullspace.ca/wiki/index.php/$TOOL_NAME"
+URL="wiki.skullspace.ca/index.php/$TOOL_NAME"
 
 if [[ "$OWNER" = "$SKULLSPACE_STR" ]]; then
    owner_icon="Skullspace_logo_square_white.svg"


### PR DESCRIPTION
Noticed this tool was creating links to the old skullspace.ca/wiki instead of its new home, as I don't believe the redirects work on gh-pages, creating links that reference the old location probably doesn't make sense.
