### PR TITLE
QR code is now added to placeholder

### DIFF
--- a/placeholder.svg
+++ b/placeholder.svg
@@ -112,7 +112,7 @@
        y="-297.63919"
        x="0"
        id="image3164"
-       xlink:href="file:///home/ben/git/skullspace_tool_label_generator/qrcode.png"
+       xlink:href="qrcode.png"
        height="1350"
        width="1350" />
   </g>


### PR DESCRIPTION
Looks like Ben's home folder was in the path. Removed it locally and tested, so this ought to work for others.
